### PR TITLE
Update gigachat auth and env config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+GIGACHAT_CLIENT_ID=your_client_id
+GIGACHAT_CLIENT_SECRET=your_client_secret

--- a/README.md
+++ b/README.md
@@ -4,19 +4,20 @@ A minimal desktop chat application that connects to GigaChat using LangGraph's R
 
 ## Requirements
 - Python 3.10+
-- A valid `GIGACHAT_API_KEY` for [GigaChat](https://developers.sber.ru/gigachat/)
+- A valid `GIGACHAT_CLIENT_ID` and `GIGACHAT_CLIENT_SECRET` for [GigaChat](https://developers.sber.ru/gigachat/)
 
-Install dependencies:
+Install dependencies using [uv](https://github.com/astral-sh/uv):
 
 ```bash
-python3 -m pip install -r requirements.txt
+uv venv .venv
+source .venv/bin/activate
+uv pip install -r requirements.txt
 ```
 
 ## Running
-Set the `GIGACHAT_API_KEY` environment variable and run the application:
+Create a `.env` file based on `.env.example` containing your `GIGACHAT_CLIENT_ID` and `GIGACHAT_CLIENT_SECRET`, then run the application:
 
 ```bash
-export GIGACHAT_API_KEY=your_token_here
 python3 -m gigachat_desktop.app
 ```
 

--- a/gigachat_desktop/app.py
+++ b/gigachat_desktop/app.py
@@ -3,19 +3,32 @@ import threading
 import tkinter as tk
 from tkinter import scrolledtext
 
+from dotenv import load_dotenv
+
 from langgraph.prebuilt import create_react_agent
 from langchain_gigachat import GigaChat
+from gigachat.utils.credentials import GigaChatCredentials
 from langchain_community.tools import DuckDuckGoSearchRun
 from langchain.agents import Tool
 
 
 def build_agent() -> "langgraph.Graph":
     """Create a simple ReAct agent using GigaChat and a search tool."""
-    api_key = os.environ.get("GIGACHAT_API_KEY")
-    if not api_key:
-        raise RuntimeError("GIGACHAT_API_KEY environment variable not set")
+    load_dotenv()
+    client_id = os.environ.get("GIGACHAT_CLIENT_ID")
+    client_secret = os.environ.get("GIGACHAT_CLIENT_SECRET")
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "GIGACHAT_CLIENT_ID and GIGACHAT_CLIENT_SECRET must be set"
+        )
 
-    llm = GigaChat(api_key=api_key, verify_ssl_certs=False)
+    credentials = GigaChatCredentials(
+        client_id=client_id,
+        client_secret=client_secret,
+        scope="GIGACHAT_API_PERS",
+    )
+
+    llm = GigaChat(credentials=credentials, verify_ssl_certs=False)
     search = DuckDuckGoSearchRun()
     tools = [
         Tool(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "gigachat_desktop"
+version = "0.1.0"
+dependencies = [
+    "langchain",
+    "langchain_gigachat",
+    "langgraph",
+    "langchain_community",
+    "duckduckgo-search",
+    "python-dotenv",
+]
+
+[build-system]
+requires = ["uv>=0.1"]
+build-backend = "uv"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ langchain_gigachat
 langgraph
 langchain_community
 duckduckgo-search
+python-dotenv


### PR DESCRIPTION
## Summary
- use `.env` for GigaChat credentials
- add uv build configuration
- document uv workflow in README
- support GigaChat credentials instead of deprecated api key

## Testing
- `python -m py_compile gigachat_desktop/app.py`